### PR TITLE
Map filters tweaks

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -220,9 +220,9 @@
     "map_page_location_permission_go_to_settings": "Turn on in Settings",
     "map_page_location_permission_reasoning_settings": "Plante works best with Location Services turned on. You'll get information about stores based on your location",
     "map_page_location_permission_title": "Location Services",
-    "map_page_no_shops_hint2": "There are no stores in the area yet. Try moving the map, add a new store or try the map filters.",
-    "@map_page_no_shops_hint2": {
-        "description": "A bottom hint on the Map Page, shown when there are no visible stores. The Filters button icon is always appended to the end of the text."
+    "map_page_no_shops_hint3": "There are no stores in the area yet. You can try to move the map or change the filters above.",
+    "@map_page_no_shops_hint3": {
+        "description": "A bottom hint on the Map Page, shown when there are no visible stores."
     },
     "map_page_no_shops_hint_in_select_shops_mode": "We don't know of any stores nearby. But you can add a new one by clicking the round button with a plus on the right!",
     "map_page_open_street_map_licence": "Data from Open Street Map",

--- a/lib/ui/map/map_page/map_page.dart
+++ b/lib/ui/map/map_page/map_page.dart
@@ -452,7 +452,7 @@ class _MapPageState extends PageStatePlante<MapPage>
                   builder: (context, ref, _) => AnimatedMapWidget(
                       child: _mode.watch(ref).buildTopActions())),
               Padding(
-                padding: const EdgeInsets.only(left: 24, right: 24),
+                padding: const EdgeInsets.only(left: 24, right: 24, top: 12),
                 child: IgnorePointer(
                     child: MapPageTimedHints(
                         loading: _model.loading,

--- a/lib/ui/map/map_page/map_page_mode_default.dart
+++ b/lib/ui/map/map_page/map_page_mode_default.dart
@@ -129,7 +129,7 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
   @override
   Widget buildTopActions() {
     return consumer((ref) {
-      if (model.loading.watch(ref)) {
+      if (model.loading.watch(ref) || !model.viewPortShopsLoaded.watch(ref)) {
         return const SizedBox();
       }
       return SizedBox(

--- a/lib/ui/map/map_page/map_page_mode_default.dart
+++ b/lib/ui/map/map_page/map_page_mode_default.dart
@@ -8,7 +8,6 @@ import 'package:plante/model/shop.dart';
 import 'package:plante/outside/map/address_obtainer.dart';
 import 'package:plante/outside/products/suggestions/suggestion_type.dart';
 import 'package:plante/ui/base/components/shop_card.dart';
-import 'package:plante/ui/base/text_styles.dart';
 import 'package:plante/ui/base/ui_utils.dart';
 import 'package:plante/ui/base/ui_value.dart';
 import 'package:plante/ui/map/components/map_filter_check_button.dart';
@@ -224,13 +223,7 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
       return;
     }
 
-    setBottomHint(RichText(
-        text: TextSpan(
-      style: TextStyles.normal,
-      children: [
-        TextSpan(text: context.strings.map_page_no_shops_hint2),
-      ],
-    )));
+    setBottomHintSimple(context.strings.map_page_no_shops_hint3);
   }
 
   @override

--- a/lib/ui/map/map_page/map_page_mode_default.dart
+++ b/lib/ui/map/map_page/map_page_mode_default.dart
@@ -24,20 +24,17 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
   static const _PREF_SHOW_ALL_SHOPS = 'MapPageModeDefault_SHOW_ALL_SHOPS';
   static const _PREF_SHOW_NOT_EMPTY_SHOPS =
       'MapPageModeDefault_SHOW_NOT_EMPTY_SHOPS';
-  static const _PREF_SHOW_EMPTY_SHOPS = 'MapPageModeDefault_SHOW_EMPTY_SHOPS';
 
   late final UIValue<bool> _showAllShops;
   late final UIValue<bool> _showNotEmptyShops;
-  late final UIValue<bool> _showEmptyShops;
   late final Map<String, MapFilter> _filterOptions;
 
   ArgCallback<bool>? _onLoadingChange;
 
   MapPageModeDefault(MapPageModeParams params)
       : super(params, nameForAnalytics: 'default') {
-    _showAllShops = createUIValue(false);
-    _showNotEmptyShops = createUIValue(true);
-    _showEmptyShops = createUIValue(false);
+    _showAllShops = createUIValue(true);
+    _showNotEmptyShops = createUIValue(false);
   }
 
   @override
@@ -68,13 +65,10 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
         prefs.getBool(_PREF_SHOW_ALL_SHOPS) ?? _showAllShops.cachedVal;
     final showNotEmptyShops = prefs.getBool(_PREF_SHOW_NOT_EMPTY_SHOPS) ??
         _showNotEmptyShops.cachedVal;
-    final showEmptyShops =
-        prefs.getBool(_PREF_SHOW_EMPTY_SHOPS) ?? _showEmptyShops.cachedVal;
     _showAllShops.setValue(showAllShops);
     _showNotEmptyShops.setValue(
       showNotEmptyShops,
     );
-    _showEmptyShops.setValue(showEmptyShops);
 
     _filterOptions = {
       _PREF_SHOW_ALL_SHOPS: MapFilter(
@@ -87,11 +81,6 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
           pref: _PREF_SHOW_NOT_EMPTY_SHOPS,
           eventShown: 'shops_with_products_shown',
           eventHidden: 'shops_with_products_hidden'),
-      _PREF_SHOW_EMPTY_SHOPS: MapFilter(
-          target: _showEmptyShops,
-          pref: _PREF_SHOW_EMPTY_SHOPS,
-          eventShown: 'empty_shops_shown',
-          eventHidden: 'empty_shops_hidden'),
     };
 
     _onLoadingChange = (_) {
@@ -132,12 +121,7 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
         }
       }
 
-      if (hasProducts && _showNotEmptyShops.cachedVal) {
-        return true;
-      } else if (!hasProducts && _showEmptyShops.cachedVal) {
-        return true;
-      }
-      return false;
+      return hasProducts && _showNotEmptyShops.cachedVal;
     };
     return shops.where(shouldShow);
   }
@@ -154,7 +138,7 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
               key: const Key('filter_listview'),
               scrollDirection: Axis.horizontal,
               children: [
-                const SizedBox(width: 16),
+                const SizedBox(width: 24),
                 MapFilterCheckButton(
                     key: const Key('button_filter_all_shops'),
                     checked: _showAllShops.watch(ref),
@@ -166,13 +150,7 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
                     checked: _showNotEmptyShops.watch(ref),
                     text: context.strings.map_page_filter_not_empty_shops2,
                     onChanged: _setShowNotEmptyShops),
-                const SizedBox(width: 8),
-                MapFilterCheckButton(
-                    key: const Key('filter_empty_shops'),
-                    checked: _showEmptyShops.watch(ref),
-                    text: context.strings.map_page_filter_empty_shops2,
-                    onChanged: _setShowEmptyShops),
-                const SizedBox(width: 16),
+                const SizedBox(width: 24),
               ]));
     });
   }
@@ -205,10 +183,6 @@ class MapPageModeDefault extends MapPageModeShopsCardBase {
 
   void _setShowAllShops(bool value) {
     _onFilterClick(_PREF_SHOW_ALL_SHOPS);
-  }
-
-  void _setShowEmptyShops(bool value) {
-    _onFilterClick(_PREF_SHOW_EMPTY_SHOPS);
   }
 
   @override

--- a/test/ui/map/map_page/map_page_map_filters_test.dart
+++ b/test/ui/map/map_page/map_page_map_filters_test.dart
@@ -39,38 +39,24 @@ void main() {
     return find.byKey(Key(keyStr)).evaluate().first.widget as T;
   }
 
-  testWidgets('User selects to display all shops', (WidgetTester tester) async {
+  testWidgets('User selects to display not empty shops',
+      (WidgetTester tester) async {
     final widget = MapPage(mapControllerForTesting: mapController);
     await commons.initIdleMapPage(widget, tester);
 
     var displayedShops = widget.getDisplayedShopsForTesting();
-    expect(displayedShops.length, lessThan(shops.length));
-
-    await tester.superTap(find.byKey(const Key('button_filter_all_shops')));
-
-    displayedShops = widget.getDisplayedShopsForTesting();
     expect(displayedShops.length, equals(shops.length));
     expect(displayedShops, containsAll(shops));
-  });
 
-  testWidgets('empty shops filter', (WidgetTester tester) async {
-    final widget = MapPage(mapControllerForTesting: mapController);
-    await commons.initIdleMapPage(widget, tester);
-
-    var displayedShops = widget.getDisplayedShopsForTesting();
-    emptyShops.forEach((shop) => expect(displayedShops, isNot(contains(shop))));
-    notEmptyShops.forEach((shop) => expect(displayedShops, contains(shop)));
-
-    await tester.tapMapFilter('filter_empty_shops');
+    await tester
+        .superTap(find.byKey(const Key('button_filter_not_empty_shops')));
 
     displayedShops = widget.getDisplayedShopsForTesting();
-    emptyShops.forEach((shop) => expect(displayedShops, contains(shop)));
-    notEmptyShops
-        .forEach((shop) => expect(displayedShops, isNot(contains(shop))));
+    expect(displayedShops.length, lessThan(shops.length));
   });
 
   testWidgets(
-      'shops with suggested products only are displayed as shops with products',
+      'shops with suggested products only - are displayed as shops with products',
       (WidgetTester tester) async {
     suggestedProductsManager.clearAllSuggestions();
     // Now empty shops have some suggested products
@@ -80,14 +66,8 @@ void main() {
     final widget = await commons.createIdleMapPage(tester);
 
     // Shops with suggestions but with 0 products are displayed
-    var displayedShops = widget.getDisplayedShopsForTesting();
+    final displayedShops = widget.getDisplayedShopsForTesting();
     emptyShops.forEach((shop) => expect(displayedShops, contains(shop)));
-
-    await tester.tapMapFilter('filter_empty_shops');
-
-    // Shops with suggestions but with 0 products are no longer displayed
-    displayedShops = widget.getDisplayedShopsForTesting();
-    emptyShops.forEach((shop) => expect(displayedShops, isNot(contains(shop))));
   });
 
   Future<void> filterEventsTest(
@@ -107,7 +87,7 @@ void main() {
       // Let's disable it!
       final String anotherFilter;
       if (key == 'button_filter_all_shops') {
-        anotherFilter = 'filter_empty_shops';
+        anotherFilter = 'button_filter_not_empty_shops';
       } else {
         anotherFilter = 'button_filter_all_shops';
       }
@@ -126,7 +106,7 @@ void main() {
     await filterEventsTest(
       tester,
       key: 'button_filter_all_shops',
-      enabledByDefault: false,
+      enabledByDefault: true,
       eventShown: 'all_shops_shown',
     );
   });
@@ -135,17 +115,8 @@ void main() {
     await filterEventsTest(
       tester,
       key: 'button_filter_not_empty_shops',
-      enabledByDefault: true,
-      eventShown: 'shops_with_products_shown',
-    );
-  });
-
-  testWidgets('empty shops filter analytics', (WidgetTester tester) async {
-    await filterEventsTest(
-      tester,
-      key: 'filter_empty_shops',
       enabledByDefault: false,
-      eventShown: 'empty_shops_shown',
+      eventShown: 'shops_with_products_shown',
     );
   });
 
@@ -157,20 +128,20 @@ void main() {
 
     var checkboxNotEmptyShops =
         firstWidgetWith<MapFilterCheckButton>('button_filter_not_empty_shops');
-    var checkboxEmptyShops =
-        firstWidgetWith<MapFilterCheckButton>('filter_empty_shops');
-    expect(checkboxNotEmptyShops.checked, isTrue);
-    expect(checkboxEmptyShops.checked, isFalse);
+    var checkboxAllShops =
+        firstWidgetWith<MapFilterCheckButton>('button_filter_all_shops');
+    expect(checkboxNotEmptyShops.checked, isFalse);
+    expect(checkboxAllShops.checked, isTrue);
 
-    await tester.tapMapFilter('filter_empty_shops');
+    await tester.tapMapFilter('button_filter_not_empty_shops');
 
     // Verify the values are changed
     checkboxNotEmptyShops =
         firstWidgetWith<MapFilterCheckButton>('button_filter_not_empty_shops');
-    checkboxEmptyShops =
-        firstWidgetWith<MapFilterCheckButton>('filter_empty_shops');
-    expect(checkboxNotEmptyShops.checked, isFalse);
-    expect(checkboxEmptyShops.checked, isTrue);
+    checkboxAllShops =
+        firstWidgetWith<MapFilterCheckButton>('button_filter_all_shops');
+    expect(checkboxNotEmptyShops.checked, isTrue);
+    expect(checkboxAllShops.checked, isFalse);
 
     // Create a new page
     widget = MapPage(
@@ -180,10 +151,10 @@ void main() {
     // Verify the values are still the same
     checkboxNotEmptyShops =
         firstWidgetWith<MapFilterCheckButton>('button_filter_not_empty_shops');
-    checkboxEmptyShops =
-        firstWidgetWith<MapFilterCheckButton>('filter_empty_shops');
-    expect(checkboxNotEmptyShops.checked, isFalse);
-    expect(checkboxEmptyShops.checked, isTrue);
+    checkboxAllShops =
+        firstWidgetWith<MapFilterCheckButton>('button_filter_all_shops');
+    expect(checkboxNotEmptyShops.checked, isTrue);
+    expect(checkboxAllShops.checked, isFalse);
   });
 }
 

--- a/test/ui/map/map_page/map_page_mode_default_test.dart
+++ b/test/ui/map/map_page/map_page_mode_default_test.dart
@@ -36,17 +36,17 @@ void main() {
     directionsManager = commons.directionsManager;
   });
 
-  testWidgets('empty shops are not displayed by default',
+  testWidgets('empty shops are displayed by default',
       (WidgetTester tester) async {
     expect(shops[0].productsCount, equals(0));
 
     final widget = await commons.createIdleMapPage(tester);
 
     final displayedShops = widget.getDisplayedShopsForTesting();
-    expect(displayedShops.length, equals(shops.length - 1));
-    expect(displayedShops, contains(shops[1]));
-    expect(displayedShops, contains(shops[2]));
-    expect(displayedShops, contains(shops[3]));
+    expect(displayedShops.length, equals(shops.length));
+    for (final shop in shops) {
+      expect(displayedShops, contains(shop));
+    }
   });
 
   testWidgets('shop click', (WidgetTester tester) async {

--- a/test/ui/map/map_page/map_page_mode_default_test.dart
+++ b/test/ui/map/map_page/map_page_mode_default_test.dart
@@ -152,20 +152,20 @@ void main() {
     final widget = MapPage(mapControllerForTesting: mapController);
     final context = await commons.initIdleMapPage(widget, tester);
 
-    expect(find.richTextContaining(context.strings.map_page_no_shops_hint2),
+    expect(find.richTextContaining(context.strings.map_page_no_shops_hint3),
         findsNothing);
 
     // No shops!
     await commons.clearFetchedShops(widget, tester, context);
 
     // 'No shops' hint is expected
-    expect(find.richTextContaining(context.strings.map_page_no_shops_hint2),
+    expect(find.richTextContaining(context.strings.map_page_no_shops_hint3),
         findsOneWidget);
 
     // Fetch shops!
     await commons.fillFetchedShops(widget, tester);
 
-    expect(find.richTextContaining(context.strings.map_page_no_shops_hint2),
+    expect(find.richTextContaining(context.strings.map_page_no_shops_hint3),
         findsNothing);
   });
 
@@ -182,14 +182,14 @@ void main() {
         .superTap(find.text(context.strings.map_page_load_shops_of_this_area));
 
     // No hints yet!
-    expect(find.richTextContaining(context.strings.map_page_no_shops_hint2),
+    expect(find.richTextContaining(context.strings.map_page_no_shops_hint3),
         findsNothing);
 
     // Shops loaded, and there are no shops!
     completer.complete([]);
     await tester.pumpAndSettle();
 
-    expect(find.richTextContaining(context.strings.map_page_no_shops_hint2),
+    expect(find.richTextContaining(context.strings.map_page_no_shops_hint3),
         findsOneWidget);
   });
 

--- a/test/ui/map/map_page/map_page_suggested_products_test.dart
+++ b/test/ui/map/map_page/map_page_suggested_products_test.dart
@@ -17,6 +17,7 @@ import 'package:plante/ui/map/map_page/map_page_model.dart';
 import 'package:plante/ui/map/map_page/map_page_testing_storage.dart';
 
 import '../../../common_mocks.mocks.dart';
+import '../../../widget_tester_extension.dart';
 import '../../../z_fakes/fake_suggested_products_manager.dart';
 import 'map_page_modes_test_commons.dart';
 
@@ -48,6 +49,8 @@ void main() {
       // Map 1
       var widget = await commons.createIdleMapPage(tester,
           key: Key('${mapKeyPrefix}map1'));
+      await tester
+          .superTap(find.byKey(const Key('button_filter_not_empty_shops')));
 
       // Shop[0] is not displayed because it has 0 products
       var displayedShops = widget.getDisplayedShopsForTesting();
@@ -60,6 +63,8 @@ void main() {
       // Map 2
       widget = await commons.createIdleMapPage(tester,
           key: Key('${mapKeyPrefix}map2'));
+      await tester
+          .superTap(find.byKey(const Key('button_filter_not_empty_shops')));
 
       // Shop[0] is now displayed because it has several suggestions
       displayedShops = widget.getDisplayedShopsForTesting();
@@ -119,6 +124,8 @@ void main() {
 
     // No markers at first
     final page = await commons.createIdleMapPage(tester);
+    await tester
+        .superTap(find.byKey(const Key('button_filter_not_empty_shops')));
     expect(page.getDisplayedShopsForTesting(), isEmpty);
 
     // Still no markers even after we push a suggestion - suggestions


### PR DESCRIPTION
- Don't show map filters when the territory is not loaded yet: https://github.com/plante-app-team/plante/issues/168
- Remove the "Empty shops" map filter: https://github.com/plante-app-team/plante/issues/172
- Display empty shops by default: https://github.com/plante-app-team/plante/issues/50
- Add a top padding to the map hints
- Reword the 'no shops in the area' hint